### PR TITLE
truncate lower triangular matrix when computing hermite form

### DIFF
--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -112,9 +112,16 @@ julia> H
         Triangularization" IEEE Transactions on Automatic Control, vol. 44,
         no. 3, Mar. 1999.
 """
-function hermite(p::PolyMatrix{T1,M,Val{W},N}, iterative::Bool=true, dᵤ::Int=-1) where {T1,M,W,N}
+function hermite(p::PolyMatrix{T1,M,Val{W},N}, iterative::Bool=true, dᵤ::Int=-1,
+  ϵ=-one(T1)) where {T1,M,W,N}
   L,U,d = _ltriang(p, iterative, dᵤ)
   n,m   = size(p)
+
+  # truncate elements close to zero
+  ϵ = ϵ < zero(ϵ) ? Base.rtoldefault(real(T1))*length(p)*d : ϵ
+  for i in eachindex(L)
+    L[i]  = abs(L[i]) < ϵ ? zero(L[i]) : L[i]
+  end
 
   # scale diagonal elements first
   Σ = [findfirst(x -> x!=0, L[:,k]) for k in 1:m]


### PR DESCRIPTION
Without truncation, roundoff errors leads to an incorrect hermite form. The truncation parameter is exposed to the user.

In most functions the returned type is passed through the constructor and truncated there, however, in the `hermite` function an intermediate result from `ltriang` is used bypassing the constructor.

As a default I put the same heuristic as in the constructor. 